### PR TITLE
Feature/midi clock pitch control

### DIFF
--- a/midiclock-qt.py
+++ b/midiclock-qt.py
@@ -128,7 +128,7 @@ class MidiClockApp:
                 color: white;
             }
         """)
-        self.prodj = ProDj()
+        self.prodj = ProDj(iface=self.args.iface)
         self.signal_bridge = SignalBridge()
 
         # Connect ProDj callbacks to signal bridge slots
@@ -176,6 +176,8 @@ def main():
     loglevels = ['debug', 'info', 'warning', 'error', 'critical']
     parser.add_argument('--loglevel', choices=loglevels, default='info',
                         help="Set the logging level (default: info).")
+    parser.add_argument('--iface', type=str,
+                        help="Name of the interface to use (e.g. eth0).")
     # Add other arguments if needed, e.g., for forcing MIDI backend eventually
 
     args = parser.parse_args()

--- a/prodj/core/prodj.py
+++ b/prodj/core/prodj.py
@@ -18,7 +18,7 @@ class OwnIpStatus(Enum):
   acquired = 3
 
 class ProDj(Thread):
-  def __init__(self):
+  def __init__(self, iface=None):
     super().__init__()
     self.cl = ClientList(self)
     self.data = DataProvider(self)
@@ -32,6 +32,7 @@ class ProDj(Thread):
     self.status_port = 50002
     self.need_own_ip = OwnIpStatus.notNeeded
     self.own_ip = None
+    self.iface = iface
 
   def start(self):
     self.keepalive_sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
@@ -105,8 +106,8 @@ class ProDj(Thread):
     # both packet types give us enough information to store the client
     if packet["type"] in ["type_ip", "type_status", "type_change"]:
       self.cl.eatKeepalive(packet)
-    if self.own_ip is None and len(self.cl.getClientIps()) > 0:
-      self.own_ip = guess_own_iface(self.cl.getClientIps())
+    if self.own_ip is None and (len(self.cl.getClientIps()) > 0 or self.iface is not None):
+      self.own_ip = guess_own_iface(self.cl.getClientIps(), self.iface)
       if self.own_ip is not None:
         logging.info("Guessed own interface {} ip {} mask {} mac {}".format(*self.own_ip))
         self.vcdj_set_iface()

--- a/prodj/gui/midiclock_widgets.py
+++ b/prodj/gui/midiclock_widgets.py
@@ -141,6 +141,7 @@ class MidiClockMainWindow(QWidget):
         self.manual_bpm_mode_active = False
         self.manual_bpm_value = 120.0
         self.tap_timestamps = []
+        self.pitch_offset = 0.0 # In milliseconds
 
         self.midi_clock_instance = None # Will hold AlsaMidiClock or RtMidiClock instance
         self.preferred_midi_backend = None # "ALSA" or "rtmidi"
@@ -159,9 +160,10 @@ class MidiClockMainWindow(QWidget):
         QTimer.singleShot(50, lambda: self.midi_led.setStyleSheet("background-color: #505050; border-radius: 10px;"))
 
     def adjust_pitch(self, direction):
-        if self.midi_clock_instance:
-            amount = self.pitch_amount_spinbox.value()
-            self.midi_clock_instance.apply_pitch_offset(amount * direction)
+        amount = self.pitch_amount_spinbox.value()
+        self.pitch_offset += amount * direction
+        self.pitch_label.setText(f"Pitch: {self.pitch_offset:.1f} ms")
+        self.update_midi_clock_source_logic()
 
     def _init_ui(self):
         main_layout = QVBoxLayout(self)
@@ -175,6 +177,12 @@ class MidiClockMainWindow(QWidget):
         controls_frame = QFrame()
         controls_frame.setFrameStyle(QFrame.StyledPanel)
         controls_layout = QHBoxLayout(controls_frame)
+
+        self.midi_led = QFrame()
+        self.midi_led.setFrameStyle(QFrame.StyledPanel)
+        self.midi_led.setFixedSize(20, 20)
+        self.midi_led.setStyleSheet("background-color: #505050; border-radius: 10px;")
+        controls_layout.addWidget(self.midi_led)
 
         self.midi_port_combo = QComboBox()
         # self.populate_midi_ports() # To be implemented
@@ -239,15 +247,12 @@ class MidiClockMainWindow(QWidget):
         self.pitch_up_button.clicked.connect(lambda: self.adjust_pitch(1))
         pitch_layout.addWidget(self.pitch_up_button)
 
+        self.pitch_label = QLabel("Pitch: 0.0 ms")
+        pitch_layout.addWidget(self.pitch_label)
+
         pitch_group.setLayout(pitch_layout)
         controls_layout.addWidget(pitch_group)
         # --- End Pitch Controls ---
-
-        self.midi_led = QFrame()
-        self.midi_led.setFrameStyle(QFrame.StyledPanel)
-        self.midi_led.setFixedSize(20, 20)
-        self.midi_led.setStyleSheet("background-color: #505050; border-radius: 10px;")
-        controls_layout.addWidget(self.midi_led)
 
         self.global_status_label = QLabel("MIDI Clock: Stopped | Source: None")
         controls_layout.addWidget(self.global_status_label)
@@ -491,7 +496,6 @@ class MidiClockMainWindow(QWidget):
             try:
                 logging.debug(f"Attempting to open MIDI port: Name='{device_name_to_open}', PortNum/ID='{port_to_open}' using {self.MidiClockImpl.__name__}")
                 self.midi_clock_instance.open(preferred_name=device_name_to_open, preferred_port=port_to_open)
-                self.midi_clock_instance.set_beat_callback(self.beat_received)
                 self.update_midi_clock_source_logic() # Set initial BPM
                 if not self.midi_clock_instance.is_alive(): # Check if thread started (it should by .start())
                     self.midi_clock_instance.start()
@@ -515,7 +519,7 @@ class MidiClockMainWindow(QWidget):
     def update_midi_clock_source_logic(self):
         if self.manual_bpm_mode_active:
             if self.midi_clock_instance and self.midi_clock_instance.is_alive():
-                self.midi_clock_instance.setBpm(self.manual_bpm_value)
+                self.midi_clock_instance.setBpm(self.manual_bpm_value, self.pitch_offset)
             self.update_global_status_label()
             return
 
@@ -589,10 +593,10 @@ class MidiClockMainWindow(QWidget):
 
         if self.midi_clock_instance and self.midi_clock_instance.is_alive():
             if final_bpm_to_set is not None and final_bpm_to_set > 0:
-                self.midi_clock_instance.setBpm(final_bpm_to_set)
+                self.midi_clock_instance.setBpm(final_bpm_to_set, self.pitch_offset)
             else:
                 logging.error("Attempting to set invalid BPM (None or <=0). Defaulting to 120.")
-                self.midi_clock_instance.setBpm(120)
+                self.midi_clock_instance.setBpm(120, self.pitch_offset)
 
         self.update_global_status_label()
 

--- a/prodj/gui/midiclock_widgets.py
+++ b/prodj/gui/midiclock_widgets.py
@@ -3,8 +3,8 @@ import sys # Moved to be among the first imports
 from PyQt5.QtWidgets import (QWidget, QVBoxLayout, QHBoxLayout, QLabel, QPushButton,
                              QComboBox, QGridLayout, QFrame, QSizePolicy, QDialog,
                              QGroupBox, QRadioButton, QDialogButtonBox, QSlider,
-                             QMessageBox) # Added QMessageBox
-from PyQt5.QtCore import Qt, pyqtSignal
+                             QMessageBox, QSpinBox) # Added QSpinBox and QMessageBox
+from PyQt5.QtCore import Qt, pyqtSignal, QTimer
 
 # MIDI Clock imports
 from prodj.midi.midiclock_rtmidi import MidiClock as RtMidiClock
@@ -141,6 +141,7 @@ class MidiClockMainWindow(QWidget):
         self.manual_bpm_mode_active = False
         self.manual_bpm_value = 120.0
         self.tap_timestamps = []
+        self.pitch_offset = 0 # In milliseconds
 
         self.midi_clock_instance = None # Will hold AlsaMidiClock or RtMidiClock instance
         self.preferred_midi_backend = None # "ALSA" or "rtmidi"
@@ -153,6 +154,16 @@ class MidiClockMainWindow(QWidget):
         self.populate_midi_ports() # Populate MIDI ports after UI is created
         self.update_player_display() # Initial population
         self.update_global_status_label() # Initial status
+
+    def beat_received(self):
+        self.midi_led.setStyleSheet("background-color: #00FF00; border-radius: 10px;")
+        QTimer.singleShot(50, lambda: self.midi_led.setStyleSheet("background-color: #505050; border-radius: 10px;"))
+
+    def adjust_pitch(self, direction):
+        amount = self.pitch_amount_spinbox.value()
+        self.pitch_offset += amount * direction
+        self.pitch_label.setText(f"Pitch: {self.pitch_offset} ms")
+        self.update_midi_clock_source_logic()
 
     def _init_ui(self):
         main_layout = QVBoxLayout(self)
@@ -208,6 +219,39 @@ class MidiClockMainWindow(QWidget):
         self.settings_button.clicked.connect(self.open_settings_dialog)
         controls_layout.addWidget(self.settings_button)
         # --- End Manual BPM Controls ---
+
+        # --- Pitch Controls ---
+        pitch_group = QGroupBox("Pitch Adjustment")
+        pitch_layout = QHBoxLayout()
+
+        self.pitch_down_button = QPushButton("-")
+        self.pitch_down_button.setFixedWidth(40)
+        self.pitch_down_button.clicked.connect(lambda: self.adjust_pitch(-1))
+        pitch_layout.addWidget(self.pitch_down_button)
+
+        self.pitch_amount_spinbox = QSpinBox()
+        self.pitch_amount_spinbox.setRange(1, 1000)
+        self.pitch_amount_spinbox.setSuffix(" ms")
+        self.pitch_amount_spinbox.setValue(10)
+        pitch_layout.addWidget(self.pitch_amount_spinbox)
+
+        self.pitch_up_button = QPushButton("+")
+        self.pitch_up_button.setFixedWidth(40)
+        self.pitch_up_button.clicked.connect(lambda: self.adjust_pitch(1))
+        pitch_layout.addWidget(self.pitch_up_button)
+
+        self.pitch_label = QLabel("Pitch: 0 ms")
+        pitch_layout.addWidget(self.pitch_label)
+
+        pitch_group.setLayout(pitch_layout)
+        controls_layout.addWidget(pitch_group)
+        # --- End Pitch Controls ---
+
+        self.midi_led = QFrame()
+        self.midi_led.setFrameStyle(QFrame.StyledPanel)
+        self.midi_led.setFixedSize(20, 20)
+        self.midi_led.setStyleSheet("background-color: #505050; border-radius: 10px;")
+        controls_layout.addWidget(self.midi_led)
 
         self.global_status_label = QLabel("MIDI Clock: Stopped | Source: None")
         controls_layout.addWidget(self.global_status_label)
@@ -451,6 +495,7 @@ class MidiClockMainWindow(QWidget):
             try:
                 logging.debug(f"Attempting to open MIDI port: Name='{device_name_to_open}', PortNum/ID='{port_to_open}' using {self.MidiClockImpl.__name__}")
                 self.midi_clock_instance.open(preferred_name=device_name_to_open, preferred_port=port_to_open)
+                self.midi_clock_instance.set_beat_callback(self.beat_received)
                 self.update_midi_clock_source_logic() # Set initial BPM
                 if not self.midi_clock_instance.is_alive(): # Check if thread started (it should by .start())
                     self.midi_clock_instance.start()
@@ -474,7 +519,7 @@ class MidiClockMainWindow(QWidget):
     def update_midi_clock_source_logic(self):
         if self.manual_bpm_mode_active:
             if self.midi_clock_instance and self.midi_clock_instance.is_alive():
-                self.midi_clock_instance.setBpm(self.manual_bpm_value)
+                self.midi_clock_instance.setBpm(self.manual_bpm_value, self.pitch_offset)
             self.update_global_status_label()
             return
 
@@ -548,10 +593,10 @@ class MidiClockMainWindow(QWidget):
 
         if self.midi_clock_instance and self.midi_clock_instance.is_alive():
             if final_bpm_to_set is not None and final_bpm_to_set > 0:
-                self.midi_clock_instance.setBpm(final_bpm_to_set)
+                self.midi_clock_instance.setBpm(final_bpm_to_set, self.pitch_offset)
             else:
                 logging.error("Attempting to set invalid BPM (None or <=0). Defaulting to 120.")
-                self.midi_clock_instance.setBpm(120)
+                self.midi_clock_instance.setBpm(120, self.pitch_offset)
 
         self.update_global_status_label()
 

--- a/prodj/midi/midiclock_alsaseq.py
+++ b/prodj/midi/midiclock_alsaseq.py
@@ -79,20 +79,11 @@ class MidiClock(Thread):
   def set_beat_callback(self, callback):
       self.beat_callback = callback
 
-  def apply_pitch_offset(self, offset_ms):
-      offset_s = math.floor(offset_ms / 1000.0)
-      offset_ns = math.floor(1e9 * (offset_ms / 1000.0 - offset_s))
-      self.time_s -= offset_s
-      self.time_ns -= offset_ns
-      if self.time_ns < 0:
-          self.time_s -= 1
-          self.time_ns += 1000000000
-
   def enqueue_events(self):
     for i in range(self.enqueue_at_once):
       send = (36, 1, 0, 0, (self.time_s, self.time_ns), (128,0), (self.client_id, self.client_port), None)
       alsaseq.output(send)
-      if self.beat_callback and i == 0:
+      if self.beat_callback and i % 6 == 0: # Blink every 1/4 note
           self.beat_callback()
       self.advance_time()
 
@@ -119,14 +110,16 @@ class MidiClock(Thread):
     self.keep_running = False
     self.join()
 
-  def setBpm(self, bpm):
+  def setBpm(self, bpm, pitch_offset=0):
     if bpm <= 0:
       logging.warning("Ignoring zero bpm")
       return
-    self.delay = 60/bpm/24
+    self.delay = (60/bpm/24) - (pitch_offset / 1000.0)
+    if self.delay < 0:
+        self.delay = 0
     self.add_s = math.floor(self.delay)
     self.add_ns = math.floor(1e9*(self.delay-self.add_s))
-    logging.info("Midi BPM %d delay %.9fs", bpm, self.delay)
+    logging.info("Midi BPM %d with pitch offset %fms, delay %.9fs", bpm, pitch_offset, self.delay)
 
 if __name__ == "__main__":
   logging.basicConfig(level=logging.INFO, format='%(levelname)s: %(message)s')

--- a/prodj/midi/midiclock_alsaseq.py
+++ b/prodj/midi/midiclock_alsaseq.py
@@ -79,11 +79,20 @@ class MidiClock(Thread):
   def set_beat_callback(self, callback):
       self.beat_callback = callback
 
+  def apply_pitch_offset(self, offset_ms):
+      offset_s = math.floor(offset_ms / 1000.0)
+      offset_ns = math.floor(1e9 * (offset_ms / 1000.0 - offset_s))
+      self.time_s -= offset_s
+      self.time_ns -= offset_ns
+      if self.time_ns < 0:
+          self.time_s -= 1
+          self.time_ns += 1000000000
+
   def enqueue_events(self):
     for i in range(self.enqueue_at_once):
       send = (36, 1, 0, 0, (self.time_s, self.time_ns), (128,0), (self.client_id, self.client_port), None)
       alsaseq.output(send)
-      if self.beat_callback and i % 24 == 0:
+      if self.beat_callback and i == 0:
           self.beat_callback()
       self.advance_time()
 
@@ -110,16 +119,14 @@ class MidiClock(Thread):
     self.keep_running = False
     self.join()
 
-  def setBpm(self, bpm, pitch_offset=0):
+  def setBpm(self, bpm):
     if bpm <= 0:
       logging.warning("Ignoring zero bpm")
       return
-    self.delay = (60/bpm/24) - (pitch_offset / 1000.0)
-    if self.delay < 0:
-        self.delay = 0
+    self.delay = 60/bpm/24
     self.add_s = math.floor(self.delay)
     self.add_ns = math.floor(1e9*(self.delay-self.add_s))
-    logging.info("Midi BPM %d with pitch offset %dms, delay %.9fs", bpm, pitch_offset, self.delay)
+    logging.info("Midi BPM %d delay %.9fs", bpm, self.delay)
 
 if __name__ == "__main__":
   logging.basicConfig(level=logging.INFO, format='%(levelname)s: %(message)s')

--- a/prodj/midi/midiclock_rtmidi.py
+++ b/prodj/midi/midiclock_rtmidi.py
@@ -37,16 +37,22 @@ class MidiClock(Thread):
   def set_beat_callback(self, callback):
     self.beat_callback = callback
 
+  def apply_pitch_offset(self, offset_ms):
+      self.delay -= offset_ms / 1000.0
+      if self.delay < 0:
+          self.delay = 0
+
   def run(self):
     cal = 0
     last = time.time()
-    beat_count = 0
+    next_beat_time = time.time()
     while self.keep_running:
       for n in range(self.calibration_cycles):
         self.midiout.send_message([0xF8])
-        if self.beat_callback and beat_count % 24 == 0:
+        now = time.time()
+        if self.beat_callback and now >= next_beat_time:
             self.beat_callback()
-        beat_count += 1
+            next_beat_time = now + self.delay * 24
         sleep_duration = self.delay - cal
         if sleep_duration < 0:
             sleep_duration = 0 # Prevent error and effectively busy-wait if already behind
@@ -64,14 +70,12 @@ class MidiClock(Thread):
     self.keep_running = False
     self.join()
 
-  def setBpm(self, bpm, pitch_offset=0):
+  def setBpm(self, bpm):
     if bpm <= 0:
       logging.warning("Ignoring zero bpm")
       return
-    self.delay = (60/bpm/24) - (pitch_offset / 1000.0)
-    if self.delay < 0:
-        self.delay = 0
-    logging.info("BPM {} with pitch offset {}ms, delay {}s".format(bpm, pitch_offset, self.delay))
+    self.delay = 60/bpm/24
+    logging.info("BPM {} delay {}s".format(bpm, self.delay))
 
 if __name__ == "__main__":
   logging.basicConfig(level=logging.INFO, format='%(levelname)s: %(message)s')

--- a/prodj/network/ip.py
+++ b/prodj/network/ip.py
@@ -2,11 +2,15 @@ import netifaces as ni
 from ipaddress import IPv4Address, IPv4Network
 import logging
 
-def guess_own_iface(match_ips):
-  if len(match_ips) == 0:
+def guess_own_iface(match_ips, iface=None):
+  if len(match_ips) == 0 and iface is None:
     return None
 
-  for iface in ni.interfaces():
+  ifaces = ni.interfaces()
+  if iface is not None:
+    ifaces = [iface]
+
+  for iface in ifaces:
     ifa = ni.ifaddresses(iface)
 
     if ni.AF_LINK not in ifa or len(ifa[ni.AF_LINK]) == 0:
@@ -20,6 +24,8 @@ def guess_own_iface(match_ips):
     for addr in ifa[ni.AF_INET]:
       if 'addr' not in addr or 'netmask' not in addr:
         continue
+      if iface is not None:
+        return iface, addr['addr'], addr['netmask'], mac
       net = IPv4Network(addr['addr']+"/"+addr['netmask'], strict=False)
       if any([IPv4Address(ip) in net for ip in match_ips]):
         return iface, addr['addr'], addr['netmask'], mac

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,6 @@ construct==2.10.70
 netifaces==0.11.0
 PyOpenGL==3.1.9
 PyQt5==5.15.11
-PyQt5-sip==12.17.0
+PyQt5-Qt5==5.15.17
+PyQt5_sip==12.17.0
 python-rtmidi==1.5.8

--- a/tests/test_midiclock_ui.py
+++ b/tests/test_midiclock_ui.py
@@ -1,0 +1,51 @@
+import unittest
+from unittest.mock import Mock, MagicMock, patch
+import sys
+
+from PyQt5.QtWidgets import QApplication
+from PyQt5.QtCore import QTimer
+
+# Add the project root to the python path
+sys.path.insert(0, '.')
+
+from prodj.gui.midiclock_widgets import MidiClockMainWindow
+
+class TestMidiClockUI(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.app = QApplication(sys.argv)
+
+    def setUp(self):
+        with patch('prodj.gui.midiclock_widgets.AlsaMidiClock', new=MagicMock()), \
+             patch('prodj.gui.midiclock_widgets.RtMidiClock', new=MagicMock()):
+            self.mock_prodj = Mock()
+            self.mock_prodj.cl.clients = []
+            self.mock_signal_bridge = Mock()
+            self.window = MidiClockMainWindow(self.mock_prodj, self.mock_signal_bridge)
+
+    def tearDown(self):
+        self.window.close()
+
+    def test_pitch_adjustment(self):
+        self.assertEqual(self.window.pitch_offset, 0)
+        self.window.pitch_amount_spinbox.setValue(50)
+        self.window.pitch_up_button.click()
+        self.assertEqual(self.window.pitch_offset, 50)
+        self.assertEqual(self.window.pitch_label.text(), "Pitch: 50 ms")
+        self.window.pitch_down_button.click()
+        self.assertEqual(self.window.pitch_offset, 0)
+        self.assertEqual(self.window.pitch_label.text(), "Pitch: 0 ms")
+
+    def test_led_blink(self):
+        self.assertEqual(self.window.midi_led.styleSheet(), "background-color: #505050; border-radius: 10px;")
+        self.window.beat_received()
+        self.assertEqual(self.window.midi_led.styleSheet(), "background-color: #00FF00; border-radius: 10px;")
+
+        # Use a timer to check if the color resets
+        QTimer.singleShot(100, self.check_led_color)
+
+    def check_led_color(self):
+        self.assertEqual(self.window.midi_led.styleSheet(), "background-color: #505050; border-radius: 10px;")
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_midiclock_ui.py
+++ b/tests/test_midiclock_ui.py
@@ -27,12 +27,14 @@ class TestMidiClockUI(unittest.TestCase):
         self.window.close()
 
     def test_pitch_adjustment(self):
-        self.window.midi_clock_instance = Mock()
-        self.window.pitch_amount_spinbox.setValue(5.0)
+        self.assertEqual(self.window.pitch_offset, 0.0)
+        self.window.pitch_amount_spinbox.setValue(2.5)
         self.window.pitch_up_button.click()
-        self.window.midi_clock_instance.apply_pitch_offset.assert_called_with(5.0)
+        self.assertEqual(self.window.pitch_offset, 2.5)
+        self.assertEqual(self.window.pitch_label.text(), "Pitch: 2.5 ms")
         self.window.pitch_down_button.click()
-        self.window.midi_clock_instance.apply_pitch_offset.assert_called_with(-5.0)
+        self.assertEqual(self.window.pitch_offset, 0.0)
+        self.assertEqual(self.window.pitch_label.text(), "Pitch: 0.0 ms")
 
     def test_led_blink(self):
         self.assertEqual(self.window.midi_led.styleSheet(), "background-color: #505050; border-radius: 10px;")

--- a/tests/test_midiclock_ui.py
+++ b/tests/test_midiclock_ui.py
@@ -27,14 +27,12 @@ class TestMidiClockUI(unittest.TestCase):
         self.window.close()
 
     def test_pitch_adjustment(self):
-        self.assertEqual(self.window.pitch_offset, 0)
-        self.window.pitch_amount_spinbox.setValue(50)
+        self.window.midi_clock_instance = Mock()
+        self.window.pitch_amount_spinbox.setValue(5.0)
         self.window.pitch_up_button.click()
-        self.assertEqual(self.window.pitch_offset, 50)
-        self.assertEqual(self.window.pitch_label.text(), "Pitch: 50 ms")
+        self.window.midi_clock_instance.apply_pitch_offset.assert_called_with(5.0)
         self.window.pitch_down_button.click()
-        self.assertEqual(self.window.pitch_offset, 0)
-        self.assertEqual(self.window.pitch_label.text(), "Pitch: 0 ms")
+        self.window.midi_clock_instance.apply_pitch_offset.assert_called_with(-5.0)
 
     def test_led_blink(self):
         self.assertEqual(self.window.midi_led.styleSheet(), "background-color: #505050; border-radius: 10px;")

--- a/tests/test_nfsclient.py
+++ b/tests/test_nfsclient.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, patch, AsyncMock
 import socket
 
 from prodj.network.nfsclient import NfsClient
@@ -28,8 +28,6 @@ class DbclientTestCase(unittest.TestCase):
 
     def tearDown(self):
         self.nc.stop() # Stop the NfsClient and its event loop
-
-from unittest.mock import AsyncMock # Add AsyncMock
 
     @patch('socket.socket', new_callable=Mock) # Keep socket mocked to prevent real network calls if any part of setup tries
     def test_buffer_download(self, mock_socket_fn): # mock_socket_fn is the mocked socket constructor


### PR DESCRIPTION
Add pitch control to synchronies djs sets with midi instruments.
1. allows now for adding a constant pitch forward in time to compensate for the delay we experienced during testing.
2. At the moment you can set a given float(eg. 1.2ms) pitch the beat output constantly.
3. You can set the float and then add or subtract pitch with the + and - button.¨
4. UI is bad you need to go fullscreen to be able to see all controls.(fix this)
5. We usually needed 1.1ms to +1.2ms pitch, so music and mini instrument lined up.
6. tested with 3 cdjs
7. found out that cdj 2000 with old firmware not working cause of packet size issues. After update, was working fine.
8. verified that midi out is following master(if cdj supports the master feature) and no manual override is set.
9. need to all blue outline for the case the output is manually set to a player that happens to be Master as well. (indicator now is green only) Future implementation